### PR TITLE
Strip whitespace from backticks-command output

### DIFF
--- a/tox_backticks.py
+++ b/tox_backticks.py
@@ -41,7 +41,7 @@ def _run_backtick(reader, venv, variable):
             redirect=True,
             returnout=True,
             ignore_ret=False,
-        )
+        ).strip()
         action.setactivity('backticks', '{}={}'.format(variable, result))
 
     setenv.definitions[variable] = result


### PR DESCRIPTION
All tests still pass with this change. I also included the more recent tox versions 3.22.x, 3.23.x 3.24.x and Python 3.9 & 3.10 in the tests which are not yet in `tox.ini`.

Closes #18
